### PR TITLE
fix ingress domain; remove ip from service yaml

### DIFF
--- a/yaml/slides_prod/slides_ingress_prod.yaml
+++ b/yaml/slides_prod/slides_ingress_prod.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: pitc-ansible-training-prod
 spec:
   rules:
-  - host: ansible-slides.k8s.puzzle.ch
+  - host: ansible-slides.puzzle.ch
     http:
       paths:
       - backend:
@@ -22,4 +22,4 @@ spec:
         pathType: ImplementationSpecific
   tls:
   - hosts:
-    - ansible-slides.k8s.puzzle.ch
+    - ansible-slides.puzzle.ch

--- a/yaml/slides_test/slides_ingress_test.yaml
+++ b/yaml/slides_test/slides_ingress_test.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: pitc-ansible-training-test
 spec:
   rules:
-  - host: ansible-slides-test.k8s.puzzle.ch
+  - host: ansible-slides-test.puzzle.ch
     http:
       paths:
       - backend:
@@ -22,4 +22,4 @@ spec:
         pathType: ImplementationSpecific
   tls:
   - hosts:
-    - ansible-slides-test.k8s.puzzle.ch
+    - ansible-slides-test.puzzle.ch

--- a/yaml/slides_test/slides_service_test.yaml
+++ b/yaml/slides_test/slides_service_test.yaml
@@ -4,9 +4,6 @@ metadata:
   name: ansible-slides
   namespace: pitc-ansible-training-test
 spec:
-  clusterIP: 10.43.128.38
-  clusterIPs:
-  - 10.43.128.38
   ports:
   - name: http
     port: 8000


### PR DESCRIPTION
fixes wrong domain in ingress definition:
removes `.k8s` from host url