### PR TITLE
Add Note for firewall setup

### DIFF
--- a/content/en/docs/04/_index.en.md
+++ b/content/en/docs/04/_index.en.md
@@ -62,6 +62,11 @@ Check `httpd.service` on group `web`:
 ```bash
  ansible -i hosts web -b -a "systemctl status httpd"
 ```
+
+{{% alert title="Hint" color="info" %}}
+The ports for ssh, dhcp and cockpit are opened by default in the firewalld. It is best, especially for documentation, to open the ports explicitly in a basic settings file.
+{{% /alert %}}
+
 {{% /details %}}
 
 ### Task 2


### PR DESCRIPTION
It is important to know that firewalld has the ssh port open by default. The note is intended to raise awareness that the port should still be opened explicitly so that this is documented.