### PR TITLE
change deprecated include module

### DIFF
--- a/content/en/docs/05/_index.en.md
+++ b/content/en/docs/05/_index.en.md
@@ -121,10 +121,10 @@ $ cat roles/base/tasks/main.yml
 ---
 # tasks file for base
 - name: set custom text
-  include: motd.yml
+  include_tasks: motd.yml
   tags: motd
 - name: install packages
-  include: packages.yml
+  include_tasks: packages.yml
   tags: packages
 
 $ cat prod.yml


### PR DESCRIPTION
The module include is marked as deprecated:

[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.