### PR TITLE
fix ingress_de resource

### DIFF
--- a/yaml/training_prod/ingress_de.yaml
+++ b/yaml/training_prod/ingress_de.yaml
@@ -3,13 +3,18 @@ apiVersion: networking.k8s.io/v1
 metadata:
   name: latest-ansible-puzzle-de
   namespace: pitc-ansible-training-prod
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    route.openshift.io/termination: edge 
   labels:
     app.kubernetes.io/name: ansible-puzzle
     app.kubernetes.io/version: 1.0.0
     public: "true"
 spec:
   tls:
-    - {}
+  - hosts:
+    - ansible.puzzle-itc.de 
+    secretName: ansible-puzzle-itc-de-secret
   rules:
     - host: ansible.puzzle-itc.de
       http:

--- a/yaml/training_prod/ingress_de.yaml
+++ b/yaml/training_prod/ingress_de.yaml
@@ -1,7 +1,7 @@
 ﻿kind: Ingress
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: latest-ansible-puzzle
+  name: latest-ansible-puzzle-de
   namespace: pitc-ansible-training-prod
   labels:
     app.kubernetes.io/name: ansible-puzzle


### PR DESCRIPTION
- use its own metaname to not overwrite the the original ingress
- use tls for a non-wildcard domain