### PR TITLE
Remove GmbH

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,7 +46,7 @@ weight = 1
 
 [[Languages.en.menu.main]]
 weight = 3
-name = "Puzzle ITC GmbH"
+name = "Puzzle ITC"
 url = "https://www.puzzle.ch"
 
 [markup]
@@ -62,7 +62,7 @@ url = "https://www.puzzle.ch"
     # guessSyntax = "true"
 
 [params]
-copyright = "Puzzle ITC GmbH"
+copyright = "Puzzle ITC"
 github_repo = "https://github.com/puzzle/ansible-training"
 imagePrefix = "puzzle_"
 enabledModule = "base"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/puzzle/ansible-training.git"
   },
-  "author": "Puzzle ITC GmbH",
+  "author": "Puzzle ITC",
   "scripts": {
     "start": "bash -c \"docker run --rm --interactive --publish 8080:8080 -v $(pwd):/src:Z klakegg/hugo:$(grep \"FROM klakegg/hugo\" Dockerfile | sed 's/FROM klakegg\\/hugo://g' | sed 's/ AS builder//g') server -p 8080 --bind 0.0.0.0\"",
     "mdlint": "markdownlint --config .markdownlint.json content *.md",


### PR DESCRIPTION
Puzzle ITC is the common name for all entities. The alternative is to replace GmbH with AG.